### PR TITLE
Add basic polylang support

### DIFF
--- a/post-type-archive-mapping.php
+++ b/post-type-archive-mapping.php
@@ -185,6 +185,7 @@ class PostTypeArchiveMapping {
 			foreach ( $post_types as $post_type => $post_id ) {
 				if ( is_post_type_archive( $post_type ) && 'default' !== $post_id && $query->is_main_query() ) {
 					$post_id = absint( $post_id );
+					$post_id = apply_filters( 'wpml_object_id', $post_id, 'page', true );
 					$query->set( 'post_type', 'page' );
 					$query->set( 'page_id', $post_id );
 					$query->set( 'redirected', true );
@@ -344,6 +345,7 @@ class PostTypeArchiveMapping {
 				'post_type'      => 'page',
 				'orderby'        => 'name',
 				'order'          => 'ASC',
+				'lang'           => '',
 			)
 		);
 		$post_types = get_post_types(


### PR DESCRIPTION
First off this changes the settings screen to display the dropdown with posts in all
languages. Without this, if you switch the admin UI language in Polylang, the setting will be unset since the post isn't available, This is a polylang specific fix, not sure if WPML needs a fix, unfortunately I dont use it so cant check. As far as i remember it either works out of the box, or we need to set `suppress_filters` to either `true|false`.

Second it translates the mapped archive page post IDs to the current language
so that they match and the translated pages are used. This should work both for
WPML and for Polylang.