### PR TITLE
add permission_callback to fix REST API error messages

### DIFF
--- a/includes/rest/class-rest.php
+++ b/includes/rest/class-rest.php
@@ -30,6 +30,7 @@ class Rest {
 			array(
 				'methods'  => 'POST',
 				'callback' => array( $this, 'get_all_terms' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 		register_rest_route(
@@ -38,6 +39,7 @@ class Rest {
 			array(
 				'methods'  => 'POST',
 				'callback' => array( $this, 'get_posts' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 		register_rest_route(
@@ -46,6 +48,7 @@ class Rest {
 			array(
 				'methods'  => 'POST',
 				'callback' => array( $this, 'get_taxonomies' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 		register_rest_route(
@@ -54,6 +57,7 @@ class Rest {
 			array(
 				'methods'  => 'POST',
 				'callback' => array( $this, 'get_image' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 		register_rest_route(
@@ -62,6 +66,7 @@ class Rest {
 			array(
 				'methods'  => 'POST',
 				'callback' => array( $this, 'get_tax_terms' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 		register_rest_route(
@@ -70,6 +75,7 @@ class Rest {
 			array(
 				'methods'  => 'POST',
 				'callback' => array( $this, 'get_tax_term_data' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 		register_rest_route(
@@ -78,6 +84,7 @@ class Rest {
 			array(
 				'methods'  => 'POST',
 				'callback' => array( $this, 'get_featured_posts' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 	}


### PR DESCRIPTION
Upon upgrading to WordPress 5.5, the plugin gives errors:

`Notice: register_rest_route was called incorrectly. The REST API route definition for ptam/v2/get_terms is missing the required permission_callback argument. For REST API routes that are intended to be public, use __return_true as the permission callback. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 5.5.0.) in .../bgsp/wp-includes/functions.php on line 5225`

I have added the `'permission_callback' => '__return_true',` argument to all instances of register_rest_route() to fix this error - as pers suggestion in [this plugin support thread](https://wordpress.org/support/topic/wordpress-5-5-php-notice-register_rest_route-was-called-incorrectly/#post-13243388).